### PR TITLE
同じ投稿内に複数同じURLがある場合に弾けるようにする

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ const app = new App({
 
 app.message(/https:\/\/twitter.com/, async ({ message, context }) => {
   const matchPettern = new RegExp('https://twitter.com/[a-zA-Z0-9_]+/status/[0-9]+', 'gi');
-  message.text.match(matchPettern).forEach(async (match) => {
+  message.text.match(matchPettern).filter(
+    (match, currentIndex, matches) => matches.indexOf(match) === currentIndex
+  ).forEach(async (match) => {
     const searchResponse = await app.client.search.messages({
       token: process.env.SLACK_USER_TOKEN,
       query: `in:<#${message.channel}> ${match}`,


### PR DESCRIPTION
携帯からURLを投稿した場合以下のようになる

```
<https://example.com|https://example.com>
```

このとき、同じURLが同一POST内に2つ存在するので、重複を弾けるようにする。